### PR TITLE
Enhance chart rendering with colored lanes and note effects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS
+
+All changes must be verified by building and running tests.
+
+Commands:
+- `cmake -S . -B build`
+- `cmake --build build`
+- `ctest --test-dir build`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,9 @@ endif()
 find_package(PkgConfig REQUIRED)
 
 # --- Dependencies via pkg-config ---
-pkg_check_modules(PORTAUDIO REQUIRED portaudio-2.0)
-pkg_check_modules(AUBIO      REQUIRED aubio)
 pkg_check_modules(SDL2       REQUIRED sdl2)
+pkg_check_modules(PORTAUDIO  portaudio-2.0)
+pkg_check_modules(AUBIO      aubio)
 
 # nlohmann_json (header-only). Prefer find_package; fallback to pkg-config include dir
 find_package(nlohmann_json QUIET)
@@ -52,10 +52,14 @@ add_executable(rocktrainer
 
 # Includes
 target_include_directories(rocktrainer PRIVATE
-        ${PORTAUDIO_INCLUDE_DIRS}
-        ${AUBIO_INCLUDE_DIRS}
         ${SDL2_INCLUDE_DIRS}
 )
+if (PORTAUDIO_FOUND AND AUBIO_FOUND)
+    target_include_directories(rocktrainer PRIVATE
+            ${PORTAUDIO_INCLUDE_DIRS}
+            ${AUBIO_INCLUDE_DIRS}
+    )
+endif()
 
 if (NOT nlohmann_json_FOUND)
     target_include_directories(rocktrainer PRIVATE ${NLOHMANN_INCLUDE_DIRS})
@@ -63,31 +67,50 @@ endif()
 
 # Library search paths
 target_link_directories(rocktrainer PRIVATE
-        ${PORTAUDIO_LIBRARY_DIRS}
-        ${AUBIO_LIBRARY_DIRS}
         ${SDL2_LIBRARY_DIRS}
 )
+if (PORTAUDIO_FOUND AND AUBIO_FOUND)
+    target_link_directories(rocktrainer PRIVATE
+            ${PORTAUDIO_LIBRARY_DIRS}
+            ${AUBIO_LIBRARY_DIRS}
+    )
+endif()
 
 # Compiler flags suggested by pkg-config (e.g., defines)
 target_compile_options(rocktrainer PRIVATE
-        ${PORTAUDIO_CFLAGS_OTHER}
-        ${AUBIO_CFLAGS_OTHER}
         ${SDL2_CFLAGS_OTHER}
 )
+if (PORTAUDIO_FOUND AND AUBIO_FOUND)
+    target_compile_options(rocktrainer PRIVATE
+            ${PORTAUDIO_CFLAGS_OTHER}
+            ${AUBIO_CFLAGS_OTHER}
+    )
+endif()
 
 # Linker flags suggested by pkg-config (critical on macOS: frameworks)
 target_link_options(rocktrainer PRIVATE
-        ${PORTAUDIO_LDFLAGS_OTHER}
-        ${AUBIO_LDFLAGS_OTHER}
         ${SDL2_LDFLAGS_OTHER}
 )
+if (PORTAUDIO_FOUND AND AUBIO_FOUND)
+    target_link_options(rocktrainer PRIVATE
+            ${PORTAUDIO_LDFLAGS_OTHER}
+            ${AUBIO_LDFLAGS_OTHER}
+    )
+endif()
 
 # Libraries
 target_link_libraries(rocktrainer PRIVATE
-        ${PORTAUDIO_LIBRARIES}
-        ${AUBIO_LIBRARIES}
         ${SDL2_LIBRARIES}
 )
+if (PORTAUDIO_FOUND AND AUBIO_FOUND)
+    target_link_libraries(rocktrainer PRIVATE
+            ${PORTAUDIO_LIBRARIES}
+            ${AUBIO_LIBRARIES}
+    )
+    target_compile_definitions(rocktrainer PRIVATE RT_ENABLE_AUDIO)
+else()
+    message(WARNING "PortAudio or aubio not found; building without audio support")
+endif()
 
 if (nlohmann_json_FOUND)
     target_link_libraries(rocktrainer PRIVATE nlohmann_json::nlohmann_json)


### PR DESCRIPTION
## Summary
- Draw six per-string colored lanes and add center hit line with beat/measure grid
- Apply perspective scaling so distant notes shrink and fade into fog
- Support sustains, simple slide visualization, and technique tag placeholders
- Allow building without PortAudio/aubio and document build/test requirements

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd99fe0cc83259cf8cbbb3c55e526