### PR TITLE
chore: add CI workflow and pre-push build hook

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running pre-push build check..."
+
+if command -v act >/dev/null 2>&1; then
+  echo "Found 'act'; running GitHub Actions workflow."
+  act -j build
+else
+  echo "'act' not found; running local cmake build."
+  cmake -S . -B build
+  cmake --build build --parallel
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ jobs:
             brew update
             brew install portaudio aubio sdl2 nlohmann-json
           else
-            choco install -y portaudio aubio sdl2 || echo "Install dependencies manually"
+            choco install -y pkgconfiglite portaudio aubio sdl2 nlohmann-json || \
+              echo "Install dependencies manually"
           fi
       - name: Configure
         run: cmake -S . -B build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up dependencies
+        shell: bash
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update
+            sudo apt-get install -y build-essential cmake pkg-config \
+              portaudio19-dev libaubio-dev libsdl2-dev nlohmann-json3-dev
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew update
+            brew install portaudio aubio sdl2 nlohmann-json
+          else
+            choco install -y portaudio aubio sdl2 || echo "Install dependencies manually"
+          fi
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build --parallel

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # rocktrainer
+
+## Development
+
+Enable the git hooks to make sure the build passes before pushing:
+
+```
+git config core.hooksPath .githooks
+```
+
+The pre-push hook runs the same build as the CI workflow. If [`act`](https://github.com/nektos/act) is installed it will execute the GitHub Actions workflow, otherwise it performs a local CMake build.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build on Linux, macOS, and Windows
- require builds to pass before push via pre-push hook using `act` when available
- document hook setup in README

## Testing
- `./.githooks/pre-push` *(fails: The following required packages were not found: portaudio-2.0)*

------
https://chatgpt.com/codex/tasks/task_e_689fdbcc72a483258653af19bfa0d9c8