### PR TITLE
Fix drawChart parameter usage to resolve build issues

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -403,9 +403,11 @@ void renderFrameGraph(App& app) {
 }
 
 // Render the play state (chart + tuner overlay)
-void drawChart(RenderState& rs, const Chart* chart, const SettingsState& settings, int64_t now_ms) {
-
+// Uses data from the app to draw the current chart at the given time.
+void drawChart(App& app, const Chart* chart, int64_t now_ms) {
   RenderState& rs = app.rs;
+  const SettingsState& settings = app.settings;
+  const GameplayStats& stats = app.stats;
 
   // First pass: render chart to offscreen texture
   SDL_SetRenderTarget(rs.r, rs.laneTex);
@@ -748,7 +750,7 @@ void updateTuner(App& app, const SDL_Event& e){ updateReturnToTitle(app,e); }
 
 void renderPlay(App& app, int64_t now_ms){
   updateGameplay(app, now_ms);
-  drawChart(app.rs, app.chart.notes.empty()?nullptr:&app.chart, now_ms, app.stats);
+  drawChart(app, app.chart.notes.empty()?nullptr:&app.chart, now_ms);
 }
 
 void updatePlay(App& app, const SDL_Event& e){


### PR DESCRIPTION
## Summary
- Refactor `drawChart` to take the entire `App` instead of individual render/settings parameters and use app state directly
- Update `renderPlay` to call new `drawChart` signature

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a02d185cd483258bc087df5d9f59d7