### PR TITLE
Document prerequisites and improve scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ endif()
 add_executable(rocktrainer
         src/main.cpp
 )
+set_target_properties(rocktrainer PROPERTIES OUTPUT_NAME NeonStrings)
 
 # Includes
 target_include_directories(rocktrainer PRIVATE

--- a/README.md
+++ b/README.md
@@ -1,11 +1,41 @@
 # rocktrainer
 
+## Prerequisites
+
+### macOS (Homebrew)
+```
+brew install portaudio aubio sdl2 nlohmann-json cmake
+```
+
+### Ubuntu/Debian (Apt)
+```
+sudo apt-get install build-essential cmake pkg-config portaudio19-dev libaubio-dev libsdl2-dev nlohmann-json3-dev
+```
+
+### Windows (vcpkg)
+```
+git clone https://github.com/microsoft/vcpkg
+./vcpkg/bootstrap-vcpkg.bat
+./vcpkg/vcpkg install portaudio aubio sdl2 nlohmann-json
+```
+
+## Build
+```
+cmake -S . -B build
+cmake --build build
+```
+
+## Run
+```
+./build/NeonStrings --device "Rocksmith" --latency-ms 20 charts/example.json
+```
+
 ## Development
 
 Enable the git hooks to make sure the build passes before pushing:
-
 ```
 git config core.hooksPath .githooks
 ```
 
-The pre-push hook runs the same build as the CI workflow. If [`act`](https://github.com/nektos/act) is installed it will execute the GitHub Actions workflow, otherwise it performs a local CMake build.
+The pre-push hook runs the same build as the CI workflow. If [`act`](https://github.com/nektos/act) is installed it will execute
+ the GitHub Actions workflow, otherwise it performs a local CMake build.

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,9 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
-sudo apt-get update
-sudo apt-get install -y build-essential cmake pkg-config \
-  portaudio19-dev libportaudio2 libaubio-dev libsdl2-dev nlohmann-json3-dev
-mkdir -p build
-cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-cmake --build . -j
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+missing=()
+for cmd in cmake pkg-config g++; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    missing+=("$cmd")
+  fi
+done
+for pkg in sdl2 portaudio-2.0 aubio nlohmann_json; do
+  if ! pkg-config --exists "$pkg"; then
+    missing+=("$pkg (pkg-config)")
+  fi
+done
+if [ "${#missing[@]}" -ne 0 ]; then
+  echo "Missing dependencies: ${missing[*]}" >&2
+  echo "Install using apt: sudo apt-get install build-essential cmake pkg-config portaudio19-dev libaubio-dev libsdl2-dev nlohmann-json3-dev" >&2
+  exit 1
+fi
+
+cmake -S . -B build
+cmake --build build
+

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-git config core.hooksPath .githooks
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
 
-# Ensure Homebrew bin is on PATH (Apple Silicon)
 export PATH="/opt/homebrew/bin:$PATH"
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew not found" >&2
+  exit 1
+fi
 
-# Install deps if missing
-brew list --versions portaudio  >/dev/null 2>&1 || brew install portaudio
-brew list --versions aubio      >/dev/null 2>&1 || brew install aubio
-brew list --versions sdl2       >/dev/null 2>&1 || brew install sdl2
-brew list --versions nlohmann-json >/dev/null 2>&1 || brew install nlohmann-json
-brew list --versions cmake >/dev/null 2>&1 || brew install cmake
+for pkg in portaudio aubio sdl2 nlohmann-json cmake; do
+  brew list --versions "$pkg" >/dev/null 2>&1 || brew install "$pkg"
+done
 
-mkdir -p build
-cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-cmake --build . -j
+cmake -S . -B build
+cmake --build build
+

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1,13 +1,18 @@
-# One-time: vcpkg install
-$vcpkg = "$PSScriptRoot\..\vcpkg"
+$ErrorActionPreference = 'Stop'
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location (Join-Path $ScriptDir '..')
+
+if (-not (Get-Command cmake -ErrorAction SilentlyContinue)) {
+    Write-Error 'cmake not found in PATH'
+}
+
+$vcpkg = Join-Path (Get-Location) 'vcpkg'
 if (!(Test-Path $vcpkg)) {
     git clone https://github.com/microsoft/vcpkg $vcpkg
-    & $vcpkg\bootstrap-vcpkg.bat
+    & "$vcpkg\bootstrap-vcpkg.bat"
 }
-& $vcpkg\vcpkg install portaudio aubio sdl2 nlohmann-json
+& "$vcpkg\vcpkg" install portaudio aubio sdl2 nlohmann-json
 
-# Build
-mkdir build -ea 0
-cd build
-cmake .. -DCMAKE_TOOLCHAIN_FILE="$vcpkg\scripts\buildsystems\vcpkg.cmake" -DCMAKE_BUILD_TYPE=RelWithDebInfo
-cmake --build . --config Release
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="$vcpkg\scripts\buildsystems\vcpkg.cmake" -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build --config Release
+

--- a/scripts/run-linux.sh
+++ b/scripts/run-linux.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-./build/rocktrainer charts/example.json
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/build-linux.sh"
+cd "$SCRIPT_DIR/.."
+./build/NeonStrings --device "Rocksmith" --latency-ms 20 charts/example.json
+

--- a/scripts/run-macos.sh
+++ b/scripts/run-macos.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-./build/rocktrainer charts/example.json
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$SCRIPT_DIR/build-macos.sh"
+cd "$SCRIPT_DIR/.."
+./build/NeonStrings --device "Rocksmith" --latency-ms 20 charts/example.json
+

--- a/scripts/run-windows.ps1
+++ b/scripts/run-windows.ps1
@@ -1,1 +1,6 @@
-.\build\Release\rocktrainer.exe charts\example.json
+$ErrorActionPreference = 'Stop'
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+& "$ScriptDir\build-windows.ps1"
+Set-Location (Join-Path $ScriptDir '..')
+.\build\Release\NeonStrings.exe --device "Rocksmith" --latency-ms 20 charts\example.json
+


### PR DESCRIPTION
## Summary
- document brew/apt/vcpkg dependencies and build/run steps
- emit NeonStrings executable from CMake
- add cross-platform scripts that verify deps, build, and run with chart

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68a0134a74748325a99fd74ce8906f68